### PR TITLE
Profile filter by annual income money field

### DIFF
--- a/vmb/matrimony/models/profiles.py
+++ b/vmb/matrimony/models/profiles.py
@@ -3,6 +3,7 @@ from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from vmb.users.models import User
 from djmoney.models.fields import MoneyField
+from djmoney.models.managers import money_manager
 
 from .base import BaseModel
 from .relations import Occupation, Qualification, Guru, Language, Country
@@ -180,7 +181,7 @@ class MaleManager(models.Manager):
 
 
 class Male(MatrimonyProfile):
-    objects = MaleManager()
+    objects = money_manager(MaleManager())
 
     class Meta:
         proxy = True
@@ -196,7 +197,7 @@ class FemaleManager(models.Manager):
 
 
 class Female(MatrimonyProfile):
-    objects = FemaleManager()
+    objects = money_manager(FemaleManager())
 
     class Meta:
         proxy = True


### PR DESCRIPTION
This will allow us to query the profile models with `MoneyField` with `Money` objects, e.g.

```
Male.objects.filter(annual_income__gte=Money(100000, 'INR'))
```

This will allow us to implement `annual_income` range filters in admin where users can enter values like: `10000 INR`, `30000 USD`, etc. But for that, we will also need to implement a custom RangeFilter for these `Money` fields.